### PR TITLE
blog: rewrite drunk-mcp-proxy intro to match current repo

### DIFF
--- a/src/data/blog/tools-drunk-mcp-proxy-introduction.md
+++ b/src/data/blog/tools-drunk-mcp-proxy-introduction.md
@@ -1,7 +1,7 @@
 ---
 author: Steven Hoang
 pubDatetime: 2026-02-19T13:00:00Z
-title: "Introducing drunk-mcp-proxy: A Production-Ready Dynamic Proxy for Model Context Protocol"
+title: "[Tools] Introducing drunk-mcp-proxy: One Gateway for MCP, OpenAPI and LLM Backends"
 postSlug: tools-drunk-mcp-proxy-introduction
 featured: true
 draft: true
@@ -11,206 +11,253 @@ tags:
   - fastmcp
   - python
   - openapi
-  - authentication
+  - llm
+  - anthropic
   - docker
-description: "Discover drunk-mcp-proxy, a production-ready dynamic proxy server for the Model Context Protocol (MCP). Deploy instantly from Docker Hub (baoduy2412/mcp-proxy) to unify multiple MCP backends, convert OpenAPI specs to MCP tools, and secure everything with enterprise authentication."
+ogImage: ""
+description: "drunk-mcp-proxy is a production-ready Python gateway that unifies multiple MCP servers, converts OpenAPI specs into MCP tools, and proxies OpenAI- and Anthropic-compatible LLM APIs from a single endpoint. Deploy it from Docker Hub (baoduy2412/mcp-proxy) in minutes."
 ---
 
-As AI tooling matures, teams inevitably end up running multiple MCP servers — one for internal docs, another for finance data, a third wrapping a REST API. Each needs its own connection, its own auth, its own client config. It doesn't scale.
+The longer my team works with the Model Context Protocol, the more obvious one problem becomes: every new capability ships as yet another MCP server. One for internal docs, one for finance data, one wrapping a REST API, one for a private LLM in LM Studio. Each has its own URL, its own auth, its own client config — and the moment two of them expose a tool called `search`, everything falls over.
 
-I built **drunk-mcp-proxy** to solve this. It's a single gateway that sits in front of all your MCP backends and OpenAPI services, giving clients one endpoint to talk to. No more juggling connections. No more tool-name collisions. No more auth headaches.
+I built **drunk-mcp-proxy** to make that pain go away. It's a single Python gateway that sits in front of all your MCP backends, your OpenAPI services, and your LLM providers, and gives every client one URL to talk to. Tool names stay isolated, auth is handled centrally, and any OpenAPI 3.0 spec becomes a usable MCP toolset without writing code.
 
 ## Table of Contents
 
 ## Why You Need an MCP Gateway
 
-As organizations adopt MCP, several pain points emerge:
+As teams adopt MCP in production, the same pain points keep surfacing:
 
-1. **Service Sprawl** — Multiple MCP servers serving different domains (finance, docs, internal tools) each requiring separate client connections
-2. **Tool Name Conflicts** — Different services exposing tools with identical names, causing confusion and errors
-3. **Authentication Complexity** — Each backend may require different auth methods (JWT, OAuth, API keys)
-4. **Client Configuration Overhead** — Every MCP client needs to know about every backend endpoint
-5. **REST API Integration** — Existing REST APIs need manual wrapping to become MCP-compatible
-6. **Operational Blind Spots** — No centralized health monitoring or logging across services
+1. **Service sprawl** — five MCP servers means five connections in every client config.
+2. **Tool name collisions** — two backends both expose `search` or `query`, and the LLM can't tell them apart.
+3. **Authentication complexity** — one backend wants a JWT, another wants Azure AD, a third just wants a bearer token.
+4. **Client churn** — every new backend forces a config push to every IDE, agent, or app.
+5. **REST APIs are not MCP** — your existing OpenAPI services need wrapping before an LLM can use them.
+6. **LLM provider fragmentation** — OpenAI, LM Studio, Ollama, OpenRouter and Anthropic all speak slightly different dialects.
+7. **No central observability** — health, logs and token usage are scattered across services.
 
-drunk-mcp-proxy addresses all of these with a clean, config-driven approach.
+`drunk-mcp-proxy` addresses all of these with a single config file and a single container.
 
 ## What is drunk-mcp-proxy?
 
-A production-ready proxy server built with Python and [FastMCP](https://github.com/jlowin/fastmcp) that acts as a central gateway for MCP services. Think of it as an API gateway, but purpose-built for the Model Context Protocol.
+A production-ready proxy server built with Python and [FastMCP](https://github.com/jlowin/fastmcp), running on the [Starlette](https://www.starlette.io/) ASGI stack. It acts as a central gateway for both MCP services and LLM providers, with three jobs:
 
-**Core capabilities:**
+1. **Aggregate MCP backends** behind one HTTP endpoint, optionally namespaced by path.
+2. **Convert OpenAPI 3.0 specs** into MCP tools at startup — no code changes to your REST APIs.
+3. **Proxy LLM traffic** through an OpenAI-compatible (and Anthropic-compatible) gateway, so any client can talk to any backend.
 
-- **Unified Interface** — Single HTTP endpoint for multiple backend MCP servers
-- **Dynamic Routing** — Path-based routing to configured backends (`/stock/mcp`, `/wiki/mcp`, etc.)
-- **Namespace Isolation** — Per-server namespaces prevent tool name conflicts
-- **OpenAPI → MCP Conversion** — Automatically convert any OpenAPI 3.0 spec into MCP tools
-- **Enterprise Authentication** — Pluggable auth providers (JWT, GitHub, Google, Azure AD, and more)
-- **Production Ready** — Health checks, CORS, structured logging, token caching, Docker support
+Core capabilities:
 
-The project is open-source and available at [github.com/baoduy/drunk-mcp-proxy](https://github.com/baoduy/drunk-mcp-proxy).
+- **Unified interface** — single HTTP endpoint for multiple backend MCP servers, OpenAPI services, and LLM providers.
+- **Dynamic routing** — path-based routing to configured backends (`/stock/mcp`, `/wiki/mcp`, `/api/mcp`).
+- **Namespace isolation** — per-server namespaces prevent tool name conflicts.
+- **OpenAPI → MCP conversion** — automatic, with method and tag filtering.
+- **OpenAI-compatible LLM gateway** — `/api/v1/chat/completions`, `/embeddings`, `/images/generations`, and more.
+- **Anthropic Messages API compatibility** — point a Claude client at the proxy and it just works.
+- **WebSocket Responses API** — native WebSocket support for OpenAI's streaming Responses API.
+- **14+ auth providers** — JWT, Bearer, Azure AD, GitHub, Google, Discord, Auth0, WorkOS, Scalekit, Descope, plus pass-through and custom.
+- **Production-ready** — health checks, CORS, structured logging, OAuth token caching, Docker image.
+
+The project is open source: [github.com/baoduy/drunk-mcp-proxy](https://github.com/baoduy/drunk-mcp-proxy).
 
 ## Quick Start with Docker Hub
 
-The fastest way to get started — no building from source required. The image is published on Docker Hub as **baoduy2412/mcp-proxy**.
+The fastest path — no source build required. The image is published as **`baoduy2412/mcp-proxy`**.
 
-### Docker Run
+### Step 1: Prepare the config directory
 
 ```bash
-docker run -d \
-  --name mcp-proxy \
-  -p 9123:9123 \
-  -v $(pwd)/data:/mcp_proxy/data \
-  -e FASTMCP_CONFIG_DIR=/mcp_proxy/data \
-  baoduy2412/mcp-proxy
+mkdir -p data/mcp data/openapi data/skills
 ```
 
-### Docker Compose (Recommended)
+### Step 2: Create `data/config.yaml`
 
-Create a `docker-compose.yml`:
+A single unified YAML file defines auth, LLM providers, and MCP/OpenAPI services:
 
 ```yaml
-version: "3"
+auth:
+  defaultProvider: basic
+  basic:
+    token: $API_KEY
+
+llm:
+  - enabled: true
+    websocket: true
+    provider: openai
+    base_url: "https://api.openai.com/v1"
+    api_key: $OPENAI_API_KEY
+
+mcp:
+  - path: /
+    spec_type: mcp
+    skill_dir: skills
+    mcp_servers:
+      playwright:
+        enabled: true
+        command: npx
+        args: ["@playwright/mcp@0.0.64"]
+        transport: stdio
+
+  - path: /api
+    spec_type: openapi
+    spec_file: openapi/petstore.yaml
+    base_url: "https://api.example.com"
+```
+
+A few things worth noting up front:
+
+- Environment variables (`$API_KEY`, `$AZURE_TENANT_ID`, `${VAR}`) are resolved when the config is loaded — keep secrets out of the file.
+- Services with `path: /` are mounted on the root MCP server and share one endpoint. Services with a specific path (`/api`, `/stock`) get their own isolated MCP server at that path.
+- `mcp_servers` accepts inline server definitions (stdio or http). For larger setups, point `spec_file` at a separate JSON file under `data/mcp/`.
+
+### Step 3: Run it
+
+`docker-compose.yml`:
+
+```yaml
 services:
   mcp-proxy:
     image: baoduy2412/mcp-proxy:latest
+    container_name: mcp-proxy-server
     ports:
-      - "9123:9123"
+      - "${FASTMCP_PORT:-9123}:${FASTMCP_PORT:-9123}"
     volumes:
-      - ./data:/mcp_proxy/data
+      - ./data:/drunk-proxy/data
+    env_file:
+      - .env
     environment:
-      - FASTMCP_CONFIG_DIR=/mcp_proxy/data
-      - FASTMCP_LOG_LEVEL=INFO
+      - FASTMCP_HOST=0.0.0.0
+      - FASTMCP_PORT=${FASTMCP_PORT:-9123}
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9123/health"]
       interval: 30s
-      timeout: 3s
+      timeout: 10s
       retries: 3
 ```
 
-Then start it:
+`.env`:
+
+```bash
+FASTMCP_PORT=9123
+FASTMCP_LOG_LEVEL=INFO
+FASTMCP_AUTH_ENABLED=false
+API_KEY=your-api-key-here
+
+# Required if you enable any OAuth provider
+FASTMCP_OAUTH_STORAGE_ENCRYPTION_KEY=your-44-character-fernet-key
+```
+
+Bring it up:
 
 ```bash
 docker-compose up -d
 curl http://localhost:9123/health
-# Response: {"status": "healthy"}
+# {"status": "healthy"}
 ```
 
-That's it. Point your MCP clients at `http://localhost:9123/mcp` and you're connected.
+That's it — clients can now point at `http://localhost:9123/mcp` for the root MCP server, and `http://localhost:9123/api/v1/chat/completions` for the LLM gateway.
 
-### Building from Source (Optional)
+### Building from source (optional)
 
-If you prefer to build locally:
+If you'd rather run from source:
 
 ```bash
 git clone https://github.com/baoduy/drunk-mcp-proxy.git
 cd drunk-mcp-proxy
 
-# Using Docker
-docker build -t drunk-mcp-proxy .
-docker run -d -p 9123:9123 -v $(pwd)/data:/mcp_proxy/data drunk-mcp-proxy
-
-# Or local development
+# Local Python
 python -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt
-export FASTMCP_CONFIG_DIR=./data
+pip install -e ".[dev]"
 python src/main.py
+
+# Or build the Docker image yourself
+docker build -t drunk-mcp-proxy .
+docker run -d -p 9123:9123 -v $(pwd)/data:/drunk-proxy/data drunk-mcp-proxy
 ```
 
 ## Architecture Overview
 
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                    MCP Client (e.g., Claude Desktop)                     │
-│                 HTTP/SSE Request with Authorization Header               │
-└────────────────────────────────┬────────────────────────────────────────┘
-                                 │
-                                 v
-┌─────────────────────────────────────────────────────────────────────────┐
-│                        drunk-mcp-proxy Server                            │
-│                                                                          │
-│   ┌─────────────┐  ┌──────────────┐  ┌───────────────────────────┐     │
-│   │ CORS        │  │ Health Check │  │ Auth Provider             │     │
-│   │ Middleware   │  │ GET /health  │  │ (JWT/GitHub/Google/Azure) │     │
-│   └─────────────┘  └──────────────┘  └───────────────────────────┘     │
-│                                                                          │
-│   ┌──────────────────────────────────────────────────────────────┐     │
-│   │  Root MCP Server (/)           POST /mcp                      │     │
-│   │  ├── Wiki MCP Proxy                                           │     │
-│   │  ├── Memory MCP Proxy                                         │     │
-│   │  └── Skills Directory Provider                                │     │
-│   └──────────────────────────────────────────────────────────────┘     │
-│   ┌──────────────────────────────────────────────────────────────┐     │
-│   │  Namespaced MCP Services                                      │     │
-│   │  ├── POST /stock/mcp  → Stock MCP Server (HTTP)              │     │
-│   │  ├── POST /wiki/mcp   → Wiki MCP Server (HTTP)               │     │
-│   │  └── POST /api/mcp    → OpenAPI Service (converted)          │     │
-│   └──────────────────────────────────────────────────────────────┘     │
-└─────────────────────────────────────────────────────────────────────────┘
+   MCP Client       LLM Client       Anthropic Client
+        \              |                   /
+         \             |                  /
+          v            v                 v
+ ┌──────────────────────────────────────────────────────┐
+ │              drunk-mcp-proxy Server                  │
+ │  Starlette ASGI + Uvicorn                            │
+ │  ┌────────────────────────────────────────────────┐ │
+ │  │ CORS  •  Auth  •  Health (/health)             │ │
+ │  └────────────────────────────────────────────────┘ │
+ │  ┌────────────────────────────────────────────────┐ │
+ │  │ MCP layer                                      │ │
+ │  │   POST /mcp           → Root (aggregated)      │ │
+ │  │   POST /stock/mcp     → Stock MCP backend      │ │
+ │  │   POST /wiki/mcp      → Wiki MCP backend       │ │
+ │  │   POST /api/mcp       → OpenAPI → MCP tools    │ │
+ │  └────────────────────────────────────────────────┘ │
+ │  ┌────────────────────────────────────────────────┐ │
+ │  │ LLM gateway (/api/v1)                          │ │
+ │  │   POST /chat/completions   (OpenAI)            │ │
+ │  │   POST /messages           (Anthropic)         │ │
+ │  │   WS   /responses          (OpenAI WS)         │ │
+ │  │   POST /embeddings, /images/generations, ...   │ │
+ │  │   GET  /models, /providers                     │ │
+ │  └────────────────────────────────────────────────┘ │
+ └──────────────────────────────────────────────────────┘
+        |               |                |
+        v               v                v
+   [MCP backends]  [OpenAPI svcs]   [OpenAI / LM Studio / Ollama / ...]
 ```
 
-The proxy is built on **Starlette** (ASGI) with **Uvicorn** as the server. Each configured service gets its own FastMCP instance, either mounted on the root path or under a dedicated namespace.
-
-### Key Components
+### Key components
 
 | Component | Purpose |
 |-----------|---------|
-| **MCPProxyServer** | Main orchestrator — loads config, creates proxy instances, starts uvicorn |
-| **StarletteApp** | ASGI app factory — mounts MCP services, adds middleware |
-| **McpProxyProvider** | Creates FastMCP proxies from MCP spec files |
-| **OpenApiMcpProvider** | Converts OpenAPI specs into MCP tools |
-| **GlobalAuthProvider** | Manages client-to-proxy authentication |
-| **AppLifespanManager** | Handles startup/shutdown of all mounted MCP apps |
-| **CacheProvider** | Token caching (memory, SQLite, or Redis) |
+| `MCPProxyServer` | Top-level orchestrator — loads config, creates proxy instances, starts uvicorn |
+| `StarletteApp` | ASGI app factory — mounts MCP services, adds middleware, wires up the LLM gateway |
+| `McpProxyProvider` | Creates FastMCP proxies from inline or external MCP spec definitions |
+| `OpenApiMcpProvider` | Converts OpenAPI 3.0 specs into MCP tools with filtering |
+| `LlmProvider` registry | Routes `/api/v1` traffic to the configured LLM backends by `{provider}_{model}` ID |
+| `GlobalAuthProvider` | Pluggable client → proxy authentication (14+ implementations) |
+| `CacheProvider` | OAuth token caching — memory, SQLite, or Redis |
+| `AppLifespanManager` | Coordinates startup/shutdown for every mounted MCP and LLM sub-app |
 
-## Configuration
+## MCP Service Configuration
 
-All configuration is driven by JSON files in the `data/` directory.
+### Root path aggregation
 
-### Service Configuration (`data/config.json`)
+Services with `path: /` are merged into a single root MCP server. Clients hit `POST /mcp` and see every tool from every aggregated backend:
 
-```json
-[
-  {
-    "path": "/",
-    "spec_file": "mcp/mcp.json",
-    "spec_type": "mcp",
-    "skill_dir": "skills"
-  },
-  {
-    "path": "/stock",
-    "spec_file": "mcp/stock.mcp.json",
-    "spec_type": "mcp",
-    "tags": ["finance", "internal"]
-  },
-  {
-    "path": "/wiki",
-    "spec_file": "mcp/wiki.mcp.json",
-    "spec_type": "mcp",
-    "tags": ["documentation"]
-  },
-  {
-    "path": "/api",
-    "spec_file": "openapi/api.openapi.json",
-    "spec_type": "openapi",
-    "base_url": "https://api.example.com",
-    "filters": {
-      "methods": ["GET", "POST"],
-      "tags": ["public"]
-    },
-    "auth": {
-      "pass_through": true
-    }
-  }
-]
+- One endpoint, one connection per client.
+- Centralised auth.
+- Useful for "always-on" tools (skills, memory, browser automation).
+
+### Namespaced services
+
+Services with a specific path get their own isolated FastMCP instance:
+
+```yaml
+mcp:
+  - path: /stock
+    spec_file: mcp/stock.mcp.json
+    spec_type: mcp
+    tags: ["finance", "internal"]
+
+  - path: /wiki
+    spec_file: mcp/wiki.mcp.json
+    spec_type: mcp
+    tags: ["documentation"]
 ```
 
-### MCP Spec Files
+Each one is reachable at `POST /<path>/mcp` (e.g. `POST /stock/mcp`). Benefits:
 
-Each MCP service references a spec file that defines how to connect to the backend:
+- **No tool name conflicts** between domains.
+- **Independent lifecycle** — restart one backend without affecting the others.
+- **Service-specific auth** per namespace if you need it.
 
-**`data/mcp/stock.mcp.json`:**
+External spec files keep `config.yaml` readable when you have many backends. `data/mcp/stock.mcp.json`:
 
 ```json
 {
@@ -223,151 +270,164 @@ Each MCP service references a spec file that defines how to connect to the backe
 }
 ```
 
-**`data/mcp/wiki.mcp.json`:**
-
-```json
-{
-  "mcpServers": {
-    "wiki": {
-      "url": "https://mcp.deepwiki.com/mcp",
-      "transport": "http"
-    }
-  }
-}
-```
-
-### Environment Variable Resolution
-
-Configuration values support `$VAR` and `${VAR}` syntax for environment variable substitution — keep secrets out of config files:
-
-```json
-{
-  "auth": {
-    "azure": {
-      "client_id": "$AZURE_CLIENT_ID",
-      "client_secret": "$AZURE_CLIENT_SECRET",
-      "tenant_id": "$AZURE_TENANT_ID"
-    }
-  }
-}
-```
-
-## Dynamic MCP Service Management
-
-### Root Path Aggregation
-
-Services with `path="/"` are mounted on a single root MCP server. Clients access all tools through one endpoint (`POST /mcp`):
-
-- Single endpoint for multiple services
-- Simplified client configuration
-- Automatic tool aggregation
-- Centralized authentication
-
-### Namespaced Services
-
-Services with specific paths (e.g., `/stock`, `/wiki`) get isolated MCP server instances at their own endpoints (`POST /stock/mcp`, `POST /wiki/mcp`):
-
-- **No tool name conflicts** — each namespace is independent
-- **Independent lifecycle** — update one service without affecting others
-- **Service-specific auth** — different authentication per namespace
-- **Logical grouping** — organize services by domain
-
 ## OpenAPI to MCP Conversion
 
-One of the most powerful features: automatically convert any OpenAPI 3.0 specification into MCP tools. No code changes to your existing REST APIs.
+This is the feature that turned the proxy from "useful" into "I'm not deploying anything else":
 
-**How it works:**
+1. Drop your OpenAPI 3.0 spec into `data/openapi/`.
+2. Add a service entry with `spec_type: openapi`.
+3. Every operation in the spec becomes an MCP tool, named from `operationId`.
+4. Query, path and body parameters are mapped automatically; HTTP methods and content types are handled for you.
 
-1. Point to an OpenAPI spec file in your config
-2. The proxy reads every endpoint and creates an MCP tool for it
-3. Tool names come from `operationId` (or are auto-generated)
-4. Parameters are mapped from query params, path params, and request body
-5. HTTP methods and content types are handled automatically
-
-**Route filtering** lets you control which endpoints are exposed:
-
-```json
-{
-  "path": "/api",
-  "spec_type": "openapi",
-  "spec_file": "openapi/api.json",
-  "base_url": "https://api.example.com",
-  "filters": {
-    "methods": ["GET", "POST"],
-    "tags": ["public", "v2"]
-  }
-}
+```yaml
+mcp:
+  - path: /api
+    spec_type: openapi
+    spec_file: openapi/api.yaml
+    base_url: "https://api.example.com"
+    filters:
+      methods: ["GET", "POST"]
+      tags: ["public", "v2"]
+    auth:
+      pass_through: true
 ```
 
-This reduces tool clutter and limits the attack surface by only exposing the endpoints you choose.
+Route filtering by method and tag keeps the tool list small and the attack surface narrow — exactly the endpoints you want exposed, nothing else.
 
 ## Enterprise Authentication
 
-The proxy supports two layers of authentication:
+The proxy handles two layers separately: **client → proxy** and **proxy → backend**.
 
-### Client → Proxy Authentication
+### Client → Proxy
 
-Control who can access the proxy. Configured via `FASTMCP_SERVER_AUTH` environment variable. Supported providers:
+Configured in the top-level `auth` block. The simplest option is bearer-token (API key) auth, which is what most teams want first:
 
-- **JWT** with JWKS validation
-- **GitHub OAuth**
-- **Google OAuth**
-- **Discord OAuth**
-- **Custom providers** via the extensible auth framework
-
-### Proxy → Backend Authentication
-
-#### Pass-Through
-
-The simplest approach — forward the client's token directly to the backend:
-
-```json
-{
-  "auth": {
-    "pass_through": true
-  }
-}
+```yaml
+auth:
+  defaultProvider: basic
+  basic:
+    token: $API_KEY
 ```
 
-Use when backends handle their own auth validation. Zero-trust friendly.
+For OAuth, you can plug in any of the 14+ providers — Azure AD, GitHub, Google, Discord, Auth0, WorkOS, Scalekit, Descope, JWT-with-JWKS, and more:
 
-#### Azure AD OAuth2
-
-For services protected by Azure AD, the proxy handles the entire OAuth2 client credentials flow automatically:
-
-```json
-{
-  "auth": {
-    "azure": {
-      "client_id": "$AZURE_CLIENT_ID",
-      "client_secret": "$AZURE_CLIENT_SECRET",
-      "tenant_id": "$AZURE_TENANT_ID",
-      "token_url": "https://login.microsoftonline.com/$AZURE_TENANT_ID/oauth2/v2.0/token",
-      "scopes": ["api://$AZURE_CLIENT_ID/.default"]
-    }
-  }
-}
+```yaml
+auth:
+  defaultProvider: azure
+  azure:
+    client_id: $AZURE_CLIENT_ID
+    client_secret: $AZURE_CLIENT_SECRET
+    tenant_id: $AZURE_TENANT_ID
 ```
 
-Features:
-- Automatic token acquisition via client credentials flow
-- In-memory token caching with expiry detection (also supports SQLite and Redis)
-- Automatic token refresh
-- Completely transparent to MCP clients
+OAuth providers require `FASTMCP_OAUTH_STORAGE_ENCRYPTION_KEY` (a 44-character Fernet key) so cached tokens are encrypted at rest.
+
+### Proxy → Backend
+
+For per-service backend auth, configure it on the service entry itself.
+
+**Pass-through** is the zero-trust friendly default — forward the client's token directly:
+
+```yaml
+- path: /api
+  spec_type: openapi
+  spec_file: openapi/api.yaml
+  auth:
+    pass_through: true
+```
+
+**Azure AD client credentials** lets the proxy acquire tokens for a private API on the client's behalf — the MCP client never sees Azure at all:
+
+```yaml
+- path: /finance
+  spec_type: openapi
+  spec_file: openapi/finance.yaml
+  auth:
+    azure:
+      client_id: $AZURE_CLIENT_ID
+      client_secret: $AZURE_CLIENT_SECRET
+      tenant_id: $AZURE_TENANT_ID
+      token_url: "https://login.microsoftonline.com/$AZURE_TENANT_ID/oauth2/v2.0/token"
+      scopes: ["api://$AZURE_CLIENT_ID/.default"]
+```
+
+Tokens are cached (memory, SQLite or Redis) and refreshed automatically before expiry. Nice when you're running multiple replicas — point them at Redis and they share the cache.
+
+## The LLM Gateway
+
+If you configure any LLM provider, the proxy automatically exposes an OpenAI-compatible API at `/api/v1`. Models are addressed as `{provider}_{model_name}`, so routing is unambiguous:
+
+- `openai_gpt-4o` → OpenAI's `gpt-4o`
+- `lms_llama-3.2` → LM Studio's `llama-3.2`
+- `oll_qwen2.5` → Ollama's `qwen2.5`
+- `ort_claude-3-5-sonnet` → OpenRouter's `claude-3-5-sonnet`
+
+### Endpoints
+
+All mounted under `/api/v1` (configurable via `FASTMCP_LLM_ROUTE_PREFIX`):
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `POST` | `/chat/completions` | OpenAI-compatible chat |
+| `POST` | `/messages` | Anthropic Messages API |
+| `WS`   | `/responses` | OpenAI WebSocket Responses API |
+| `POST` | `/embeddings` | Text embeddings |
+| `POST` | `/images/generations` | Image generation |
+| `POST` | `/audio/transcriptions` | Whisper-style transcription |
+| `POST` | `/audio/translations` | Audio translation |
+| `GET`  | `/models` | List models across all providers |
+| `GET`  | `/providers` | List configured providers |
+
+### Anthropic compatibility (the killer feature for Claude Code users)
+
+The `/messages` endpoint speaks the Anthropic Messages API on the front, and any OpenAI-compatible backend on the back. That means you can point [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — or any Anthropic client — at a local LM Studio model, an Ollama model, or an OpenRouter model:
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:9123/api/v1
+export ANTHROPIC_AUTH_TOKEN=$API_KEY
+claude --model lms_llama-3.2
+```
+
+The proxy handles the conversion in both directions: system prompts, multimodal content (text, base64 images, URL images), tool use, tool results, streaming SSE events, `stop_sequences` ↔ `stop`, and finish-reason mapping.
+
+### WebSocket Responses API
+
+The `/responses` WebSocket endpoint implements OpenAI's Responses API protocol. Native WebSocket is used when the upstream provider supports it (set `websocket: true` on the provider); otherwise the proxy falls back to the HTTP Responses API transparently.
+
+```javascript
+const ws = new WebSocket("ws://localhost:9123/api/v1/responses", {
+  headers: { Authorization: "Bearer YOUR_API_KEY" }
+});
+
+ws.send(JSON.stringify({
+  type: "response.create",
+  response: {
+    model: "openai_gpt-4o",
+    instructions: "You are a helpful assistant.",
+    input: [{ type: "message", role: "user", content: "Hello!" }]
+  }
+}));
+
+ws.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+  console.log(data.type, data);
+};
+```
+
+> The `previous_response_id` continuation feature only works for providers running on native WebSocket. HTTP-fallback providers will return an error if you try to use it.
 
 ## Skills Directory Provider
 
-Expose Markdown-based skill documentation as MCP resources. This gives LLMs structured knowledge about your code patterns, best practices, and domain-specific information.
+Skills are Markdown files that turn into MCP resources, so an LLM can read your code patterns and conventions as context. Point a service at a directory:
 
-```json
-{
-  "path": "/",
-  "spec_type": "mcp",
-  "skill_dir": "skills"
-}
+```yaml
+mcp:
+  - path: /
+    spec_type: mcp
+    skill_dir: skills
 ```
 
-Directory structure:
+Directory layout:
 
 ```
 data/skills/
@@ -381,44 +441,49 @@ data/skills/
         └── SKILL.md
 ```
 
-Each `SKILL.md` becomes an MCP resource that AI assistants can read and use as context.
+Each `SKILL.md` is exposed as an MCP resource. This pairs nicely with the [DKNet libraries](/posts/dotnet-08-dknet-introduction <!-- verify slug -->) — drop your DDD or EF Core conventions into a skill folder and every connected agent can read them.
 
 ## Production Deployment
 
-### Environment Variables
+### Environment variables
+
+The essentials (full list in `.env.sample`):
 
 ```bash
 # Server
 FASTMCP_PORT=9123
 FASTMCP_HOST=0.0.0.0
 FASTMCP_LOG_LEVEL=INFO
-FASTMCP_CONFIG_DIR=./data
+FASTMCP_CONFIG_DIR=/drunk-proxy/data
+FASTMCP_AUTH_ENABLED=false
 
 # CORS
-CORS_ALLOW_ORIGINS=https://app.example.com
-CORS_ALLOW_METHODS=GET,POST
-CORS_ALLOW_HEADERS=*
+FASTMCP_CORS_ALLOW_ORIGINS=https://app.example.com
 
-# Auth (Azure AD example)
-AZURE_CLIENT_ID=your-client-id
-AZURE_CLIENT_SECRET=your-client-secret
-AZURE_TENANT_ID=your-tenant-id
+# Bearer auth
+API_KEY=your-api-key-here
 
-# Token caching
-OAUTH_STORAGE_TYPE=memory  # or sqlite, redis
+# OAuth (required for any OAuth provider)
+FASTMCP_OAUTH_STORAGE_ENCRYPTION_KEY=your-44-character-fernet-key
+
+# Azure AD (when used)
+AZURE_CLIENT_ID=...
+AZURE_CLIENT_SECRET=...
+AZURE_TENANT_ID=...
 ```
 
-### Health Monitoring
+### Health monitoring
 
-The `/health` endpoint returns `{"status": "healthy"}` — use it for:
+`GET /health` returns `{"status": "healthy"}`. Wire it into:
 
-- Docker/Kubernetes readiness and liveness probes
-- Load balancer health checks
-- Monitoring system integrations
+- Kubernetes readiness and liveness probes
+- Docker healthchecks (already configured in the sample compose file)
+- Your load balancer
+- Your monitoring stack
 
 ### Kubernetes
 
-The Docker Hub image (`baoduy2412/mcp-proxy`) works directly in Kubernetes deployments:
+The Docker Hub image works directly in a Deployment:
 
 ```yaml
 apiVersion: apps/v1
@@ -427,7 +492,13 @@ metadata:
   name: mcp-proxy
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: mcp-proxy
   template:
+    metadata:
+      labels:
+        app: mcp-proxy
     spec:
       containers:
         - name: mcp-proxy
@@ -436,67 +507,87 @@ spec:
             - containerPort: 9123
           env:
             - name: FASTMCP_CONFIG_DIR
-              value: /mcp_proxy/data
+              value: /drunk-proxy/data
           readinessProbe:
-            httpGet:
-              path: /health
-              port: 9123
+            httpGet: { path: /health, port: 9123 }
           livenessProbe:
-            httpGet:
-              path: /health
-              port: 9123
+            httpGet: { path: /health, port: 9123 }
           volumeMounts:
             - name: config
-              mountPath: /mcp_proxy/data
+              mountPath: /drunk-proxy/data
       volumes:
         - name: config
           configMap:
             name: mcp-proxy-config
 ```
 
+For Helm-managed deployments, the same image plugs straight into the [drunk-charts library](/posts/tools-drunk-helm-charts-library <!-- verify slug -->) — drop it in as a deployment, mount a ConfigMap for `data/`, expose `9123`, and you're done.
+
 ## Real-World Use Cases
 
-### Unified Gateway for Internal Services
-
-Multiple internal MCP services (HR, Finance, Documentation) accessible through one endpoint. Clients configure a single URL instead of managing N connections.
-
-### Secure API Gateway with Azure AD
-
-Expose an internal REST API (protected by Azure AD) as MCP tools. The proxy handles token acquisition and refresh — MCP clients never need Azure credentials.
-
-### Multi-Tenant SaaS
-
-Namespace isolation per tenant (`/tenant-a/mcp`, `/tenant-b/mcp`). Each tenant gets independent configuration, authentication, and tool sets.
-
-### Legacy API Integration
-
-Wrap existing REST/OpenAPI services as MCP tools without modifying the original APIs. The proxy handles protocol translation automatically.
+- **Unified gateway for internal services.** HR, Finance and Docs MCP servers behind one URL. Clients configure once.
+- **Secure API gateway with Azure AD.** Wrap a private REST API protected by Azure AD; the proxy handles token acquisition and refresh, MCP clients never touch Azure.
+- **Multi-tenant SaaS.** Per-tenant namespaces (`/tenant-a/mcp`, `/tenant-b/mcp`) with independent config and auth.
+- **Legacy API integration.** Existing OpenAPI services become MCP tools with zero code changes.
+- **BYO-LLM for Claude Code.** Run Claude Code against a local LM Studio model via the Anthropic compatibility shim.
+- **Hybrid LLM routing.** Send embeddings to a cheap provider, code generation to a beefy one, and image work to a third — all through the same `/api/v1`.
 
 ## Best Practices
 
-1. **Use namespace isolation** for logically distinct services — prevents conflicts and enables independent updates
-2. **Filter OpenAPI routes** with method and tag filters — reduces attack surface and tool clutter
-3. **Never commit secrets** — use environment variable substitution (`$VAR`) in all config files
-4. **Configure specific CORS origins** — avoid wildcards in production
-5. **Enable health checks** — critical for container orchestration and monitoring
-6. **Use token caching** — Redis or SQLite for distributed deployments to avoid token storms
-7. **Set appropriate log levels** — `INFO` for production, `DEBUG` for troubleshooting
-8. **Use the Docker Hub image** (`baoduy2412/mcp-proxy`) for consistent, reproducible deployments
+1. **Use namespaces for distinct domains.** Independent paths prevent tool conflicts and let you redeploy services in isolation.
+2. **Filter OpenAPI routes.** Use `methods` and `tags` filters to expose only what an LLM should touch.
+3. **Never commit secrets.** Use `$VAR` substitution everywhere; keep real values in `.env` or a secrets manager.
+4. **Pin CORS origins in production.** Wildcards are a debugging tool, not a deployment.
+5. **Enable health checks.** Required for sensible behaviour in Docker, Kubernetes, and behind a load balancer.
+6. **Cache OAuth tokens externally.** Redis or SQLite when you scale beyond one replica — otherwise each pod stampedes the token endpoint.
+7. **Set provider-specific `websocket: true` only when it's supported.** Wrong here and the streaming experience degrades silently to HTTP polling.
+8. **Use the Docker Hub image.** `baoduy2412/mcp-proxy` is the supported deployment path; build from source only when you're hacking on the proxy itself.
 
 ## Conclusion
 
-drunk-mcp-proxy simplifies the complexity of managing multiple MCP services and integrating REST APIs into the MCP ecosystem. With dynamic routing, namespace isolation, automatic OpenAPI conversion, and enterprise authentication, it provides a solid foundation for organizations building AI-powered applications at scale.
+`drunk-mcp-proxy` collapses the moving parts of a real-world MCP setup into one container with one config file. You get:
 
-Whether you're connecting internal tools, exposing external APIs, or building a multi-tenant platform — pull the image from Docker Hub and have a production-ready MCP gateway running in minutes:
+- One endpoint for many MCP backends, with proper namespace isolation.
+- Automatic OpenAPI → MCP conversion, so existing REST APIs become first-class tools.
+- An OpenAI-compatible LLM gateway with Anthropic and WebSocket Responses API support — enough to let Claude Code, an OpenAI client and a custom agent all talk to the same backend pool.
+- Enterprise auth with 14+ providers and per-backend token handling.
+- A production-ready Docker image with health checks, CORS and structured logging built in.
+
+If you're hand-rolling MCP client configs across half a dozen backends, or wrapping OpenAPI services by hand, pull the image and try it:
 
 ```bash
-docker run -d -p 9123:9123 -v $(pwd)/data:/mcp_proxy/data baoduy2412/mcp-proxy
+docker run -d -p 9123:9123 -v $(pwd)/data:/drunk-proxy/data baoduy2412/mcp-proxy
 ```
 
 ## References
 
-- **GitHub Repository**: [github.com/baoduy/drunk-mcp-proxy](https://github.com/baoduy/drunk-mcp-proxy)
+- **GitHub repo**: [github.com/baoduy/drunk-mcp-proxy](https://github.com/baoduy/drunk-mcp-proxy)
 - **Docker Hub**: [baoduy2412/mcp-proxy](https://hub.docker.com/r/baoduy2412/mcp-proxy)
-- **Technical Documentation**: [deepwiki.com/baoduy/drunk-mcp-proxy](https://deepwiki.com/baoduy/drunk-mcp-proxy)
+- **Project docs**: [baoduy.github.io/drunk-mcp-proxy](https://baoduy.github.io/drunk-mcp-proxy/)
+- **DeepWiki**: [deepwiki.com/baoduy/drunk-mcp-proxy](https://deepwiki.com/baoduy/drunk-mcp-proxy)
 - **Model Context Protocol**: [modelcontextprotocol.io](https://modelcontextprotocol.io)
 - **FastMCP**: [github.com/jlowin/fastmcp](https://github.com/jlowin/fastmcp)
+- **Starlette**: [starlette.io](https://www.starlette.io/)
+
+## Related Articles
+
+- [[Tools] Drunk Charts: A Reusable Helm Library for Kubernetes Deployments](/posts/tools-drunk-helm-charts-library <!-- verify slug -->)
+- [[.NET] DKNet: An Opinionated DDD + EF Core Toolkit](/posts/dotnet-08-dknet-introduction <!-- verify slug -->)
+- [[Az] Day 11: Exposing a Private AKS Application via Cloudflare Tunnel](/posts/az-11-private-aks-expose-public-app-with-cloudflare-tunnel <!-- verify slug -->)
+
+## Thank You
+
+Thanks for reading — if `drunk-mcp-proxy` saves you from yet another bespoke MCP gateway, that's exactly what it's for. Feedback, issues and PRs are very welcome on the [GitHub repo](https://github.com/baoduy/drunk-mcp-proxy).
+
+**Steven** | _[GitHub](https://github.com/baoduy)_
+
+---
+
+### Reviewer checklist
+
+1. Verify the related-article slugs (`tools-drunk-helm-charts-library`, `dotnet-08-dknet-introduction`, `az-11-private-aks-expose-public-app-with-cloudflare-tunnel`) match the live posts and drop the `<!-- verify slug -->` markers.
+2. Confirm the Docker Hub image tag strategy — `latest` here, but pin a version (`baoduy2412/mcp-proxy:1.x.y`) if you're recommending production use at publish time.
+3. Double-check the LLM provider example versions (`@playwright/mcp@0.0.64`, etc.) still match the current `.env.sample` and `data/` samples in the repo on publish day.
+4. Confirm the `FASTMCP_OAUTH_STORAGE_ENCRYPTION_KEY` length (44 chars / Fernet key) and the `FASTMCP_LLM_ROUTE_PREFIX` default haven't changed.
+5. Update `pubDatetime` to the actual publish time and flip `draft: false` once happy.
+6. Consider adding a hero image (architecture diagram from the repo's `diagram.svg`) as `ogImage`.


### PR DESCRIPTION
Rewrites the draft post `src/data/blog/tools-drunk-mcp-proxy-introduction.md` to align with the current upstream [drunk-mcp-proxy](https://github.com/baoduy/drunk-mcp-proxy) repo.

## What changed and why

The existing draft had factual drift from the live repo. The rewrite reflects the current README:

- **Config format**: JSON array → unified `data/config.yaml` with top-level `auth`, `llm`, `mcp` sections.
- **Volume mount**: `/mcp_proxy/data` → `/drunk-proxy/data` (matches the published Docker image).
- **Authentication**: replaced the old `FASTMCP_SERVER_AUTH` env-var story with the current pluggable `auth.defaultProvider` model (14+ providers: Bearer, JWT, Azure AD, GitHub, Google, Discord, Auth0, WorkOS, Scalekit, Descope, pass-through, custom).
- **Added the LLM gateway section** — `/api/v1` OpenAI-compatible endpoints (chat, embeddings, images, audio, models, providers) with the `{provider}_{model}` routing convention.
- **Added Anthropic Messages API compatibility** (`/api/v1/messages`) and the Claude Code CLI use case.
- **Added the WebSocket Responses API** section with provider `websocket: true` semantics and the HTTP fallback caveat.
- **Updated env vars**: added `FASTMCP_OAUTH_STORAGE_ENCRYPTION_KEY` (44-char Fernet key) and `FASTMCP_AUTH_ENABLED`; corrected `FASTMCP_CORS_ALLOW_ORIGINS`.
- **Rewrote the architecture diagram** to show the LLM gateway alongside MCP services.
- Tightened the hook, kept the DrunkCoding template (hook → thesis → TOC → why → what → quick start → architecture → features → best practices → conclusion → references → related articles → thank you), and added a reviewer checklist.

Title also retagged with `[Tools]` prefix to match the rest of the `tools-*` series.

## Reviewer checklist (also at the bottom of the post)

2. Confirm Docker Hub image tag strategy (`latest` vs pinned version).
3. Double-check sample versions (`@playwright/mcp@0.0.64`) still match the repo on publish day.
4. Confirm `FASTMCP_OAUTH_STORAGE_ENCRYPTION_KEY` (44-char Fernet) and `FASTMCP_LLM_ROUTE_PREFIX` defaults.
5. Update `pubDatetime` and flip `draft: false` when ready.
6. Consider using `diagram.svg` from the repo as the `ogImage`.

Tracked in [DRU-3](mention://issue/8828c979-be9d-4071-ad28-501cc3d278b7).