### PR TITLE
[DRK-486] Widen blog content width

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -55,7 +55,7 @@ html[data-theme="dark"] {
 }
 
 @utility max-w-app {
-  @apply max-w-3xl;
+  @apply max-w-4xl;
 }
 
 .active-nav {


### PR DESCRIPTION
Widen the blog content width by bumping the `max-w-app` Tailwind utility from `max-w-3xl` (48rem/768px) to `max-w-4xl` (56rem/896px) in `src/styles/global.css`.

This single token drives the content width for `section`, `footer`, and every layout/component using `max-w-app`.

Route B config-only change — no test surface (blog repo, no test framework).